### PR TITLE
fix in case of store replacing

### DIFF
--- a/pystore/store.py
+++ b/pystore/store.py
@@ -69,7 +69,7 @@ class store(object):
 
     def list_collections(self):
         # lists collections (subdirs)
-        return utils.subdirs(self.datastore)
+        return os.listdir(self.datastore)
 
     def collection(self, collection, overwrite=False):
         if collection in self.collections and not overwrite:


### PR DESCRIPTION
Hi Ran , today i have seen this issue trying to create/replace a collection is searching for the collection name but list of collections were getting the subdirs of datastore , at least in my side seems to be fixed.

I discover the error in the method def collection ,but it was coming from the list_collection method

Thanks for your library and your time!