### PR TITLE
Drop `os.path.join` from path functions

### DIFF
--- a/pystore/utils.py
+++ b/pystore/utils.py
@@ -18,21 +18,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-from datetime import datetime
 import json
+import os
 import shutil
-import pandas as pd
+from datetime import datetime
+
 import numpy as np
+import pandas as pd
 from dask import dataframe as dd
+
+from . import config
 
 try:
     from pathlib import Path
+
     Path().expanduser()
 except (ImportError, AttributeError):
     from pathlib2 import Path
-
-from . import config
 
 
 def read_csv(urlpath, *args, **kwargs):
@@ -70,8 +72,8 @@ def datetime_to_int64(df):
     """
 
     if isinstance(df.index, dd.Index) and (
-            isinstance(df.index, pd.DatetimeIndex) and
-            any(df.index.nanosecond) > 0):
+        isinstance(df.index, pd.DatetimeIndex) and any(df.index.nanosecond) > 0
+    ):
         df.index = df.index.astype(np.int64)  # / 1e9
 
     return df
@@ -79,8 +81,11 @@ def datetime_to_int64(df):
 
 def subdirs(d):
     """ use this to construct paths for future storage support """
-    return [o.parts[-1] for o in Path(d).iterdir()
-            if o.is_dir() and o.parts[-1] != "_snapshots"]
+    return [
+        o.parts[-1]
+        for o in Path(d).iterdir()
+        if o.is_dir() and o.parts[-1] != "_snapshots"
+    ]
 
 
 def path_exists(path):
@@ -107,12 +112,12 @@ def write_metadata(path, metadata={}):
 
 def make_path(*args):
     """ use this to construct paths for future storage support """
-    return Path(os.path.join(*args))
+    return Path(*args)
 
 
 def get_path(*args):
     """ use this to construct paths for future storage support """
-    return Path(os.path.join(config.DEFAULT_PATH, *args))
+    return Path(config.DEFAULT_PATH, *args)
 
 
 def set_path(path):
@@ -122,17 +127,16 @@ def set_path(path):
     else:
         path = path.rstrip("/").rstrip("\\").rstrip(" ")
         if "://" in path and "file://" not in path:
-            raise ValueError(
-                "PyStore currently only works with local file system")
+            raise ValueError("PyStore currently only works with local file system")
 
     config.DEFAULT_PATH = path
     path = get_path()
 
-    # if path ot exist - create it
+    # if path does not exist - create it
     if not path_exists(get_path()):
         os.makedirs(get_path())
 
-    return get_path
+    return get_path()
 
 
 def list_stores():


### PR DESCRIPTION
As mentioned in #27, sometimes the path functions try to use `os.path.join` to concatenate `pathlib.Path` and `str` objects. There is no need to use that function, because `pathlib.Path` itself already provides the concatenation.

Also, checking out the repository on Windows raised an error because there was a zero byte file called `Icon\r`, which is an illegal filename on Windows.