### PR TITLE
Add item method to store object

### DIFF
--- a/pystore/store.py
+++ b/pystore/store.py
@@ -90,12 +90,9 @@ class store(object):
         self._create_collection(collection, overwrite)
         return Collection(collection, self.datastore, self.engine)
     
-    def item(self, item_path):
+    def item(self, collection, item):
         # bypasses collection
-        if not os.path.exists(item_path):
-            raise ValueError("Item path `%s` does not exist" % item_path)
-        item_path = item_path.split("\\")
-        return self.collection(item_path[-2]).item(item_path[-1])
+        return self.collection(collection).item(item)
         
         
         

--- a/pystore/store.py
+++ b/pystore/store.py
@@ -89,3 +89,13 @@ class store(object):
         # create it
         self._create_collection(collection, overwrite)
         return Collection(collection, self.datastore, self.engine)
+    
+    def item(self, item_path):
+        # bypasses collection
+        if not os.path.exists(item_path):
+            raise ValueError("Item path `%s` does not exist" % item_path)
+        item_path = item_path.split("\\")
+        return self.collection(item_path[-2]).item(item_path[-1])
+        
+        
+        


### PR DESCRIPTION
Add simple utility method which bypasses creating a separate collection object. Useful for cases in which only one item is needed.