### PR TITLE
Add argument to control duplicates in append

### DIFF
--- a/pystore/collection.py
+++ b/pystore/collection.py
@@ -149,8 +149,46 @@ class Collection(object):
             self._list_items_threaded()
 
     def append(self, item, data, npartitions=None, epochdate=False,
-               threaded=False, reload_items=False, **kwargs):
+               threaded=False, reload_items=False, remove_duplicates=None,
+               **kwargs):
+        """Append new data to the collection.
 
+        Saves new data to the collection and optionially removes duplicates
+        within the data.
+
+        Parameters
+        ----------
+        item
+        data
+        npartitions
+        epochdate
+        threaded
+        reload_items
+        remove_duplicates : str, optional (default=None)
+            Defines how duplicates within the combined dataframe will be
+                handled.
+            None = no check for duplicated data. This is the fastest option
+                but the user is responsible for not having an overlap
+                between the new and old data
+            "index" = For data with unique index but non unique row values.
+                Rows with duplicated indices will be deleted. Ignores the
+                values
+            "values" = For data with non unique index but unique row values.
+                Rows with duplicated values will be deleted. Ignores the index
+            "all" = For data with unique index and unique row values. Rows
+                with duplicated indices will be deleted first and then all
+                rows with duplicated values will be deleted
+            "values_in_index" = For data with non unique index but unique row
+                values within index duplicates. Rows with duplicated values
+                within the same index will be deleted
+
+        kwargs
+
+        Returns
+        -------
+
+        """
+        
         if not utils.path_exists(self._item_path(item)):
             raise ValueError(
                 """Item do not exists. Use `<collection>.write(...)`""")
@@ -175,11 +213,46 @@ class Collection(object):
         if data.index.name == "":
             data.index.name = "index"
 
-        # combine old dataframe with new
+        # get old and new dataframe
         current = self.item(item)
         new = dd.from_pandas(data, npartitions=1)
-        combined = dd.concat([current.data, new]).drop_duplicates(keep="last")
 
+        # combine old dataframe with new and optionally remove duplicates from 
+        # combined dataframe
+        idx_name = combined.index.name
+        if remove_duplicates is None:
+            # drops no duplicates
+            combined = dd.concat([current.data, new])
+        elif remove_duplicates == 'index':
+            # drops all rows with duplicated indices (except the last one)
+            # ignores the values
+            combined = dd.concat([current.data, new])\
+                .reset_index()\
+                .drop_duplicates(subset=idx_name, keep="last")\
+                .set_index(idx_name)
+        elif remove_duplicates == 'values':
+            # drops only rows with duplicated column values. Ignores the index
+            combined = dd.concat([current.data, new])\
+                .drop_duplicates(keep="last")
+        elif remove_duplicates == 'all':
+            # drops rows with duplicated indices first then drops duplicated 
+            # column values
+            combined = dd.concat([current.data, new])\
+                .reset_index()\
+                .drop_duplicates(subset=idx_name, keep="last")\
+                .set_index(idx_name)\
+                .drop_duplicates(keep="last")
+        elif remove_duplicates == 'values_in_index':
+            # drops all rows with duplicated values within an duplicated index
+            combined = dd.concat([current.data, new])\
+                .reset_index()\
+                .drop_duplicates(keep="last")\
+                .set_index(idx_name)
+        else:
+            raise ValueError(
+                """argument remove_duplicates must either be None, 'index', 
+                'values', 'all' or 'values_in_index'""")     
+        
         if npartitions is None:
             memusage = combined.memory_usage(deep=True).sum()
             if isinstance(combined, dd.DataFrame):

--- a/pystore/collection.py
+++ b/pystore/collection.py
@@ -219,31 +219,24 @@ class Collection(object):
 
         # combine old dataframe with new and optionally remove duplicates from 
         # combined dataframe
-        idx_name = combined.index.name
+        idx_name = data.index.name
         if remove_duplicates is None:
-            # drops no duplicates
             combined = dd.concat([current.data, new])
         elif remove_duplicates == 'index':
-            # drops all rows with duplicated indices (except the last one)
-            # ignores the values
             combined = dd.concat([current.data, new])\
                 .reset_index()\
                 .drop_duplicates(subset=idx_name, keep="last")\
                 .set_index(idx_name)
         elif remove_duplicates == 'values':
-            # drops only rows with duplicated column values. Ignores the index
             combined = dd.concat([current.data, new])\
                 .drop_duplicates(keep="last")
         elif remove_duplicates == 'all':
-            # drops rows with duplicated indices first then drops duplicated 
-            # column values
             combined = dd.concat([current.data, new])\
                 .reset_index()\
                 .drop_duplicates(subset=idx_name, keep="last")\
                 .set_index(idx_name)\
                 .drop_duplicates(keep="last")
         elif remove_duplicates == 'values_in_index':
-            # drops all rows with duplicated values within an duplicated index
             combined = dd.concat([current.data, new])\
                 .reset_index()\
                 .drop_duplicates(keep="last")\


### PR DESCRIPTION
Adds the `remove_duplicates` argument to ` collection.append()` to control how duplicates within the old and the new appended data are handled.
Also added some documentation.
 
It should be discussed if the `remove_duplicates="all"` option is useful or not.

It should also be discussed if the default value `remove_duplicates=None` is the correct one.
To be backwards compatible it needs to be set to `remove_duplicates='values'`.

This only works for pd.Dataframes with single level index yet.