### PR TITLE
deprecate 'in' operator to be compatible with pandas 1.2.0 onwards

### DIFF
--- a/pystore/collection.py
+++ b/pystore/collection.py
@@ -120,7 +120,7 @@ class Collection(object):
 
         if epochdate or "datetime" in str(data.index.dtype):
             data = utils.datetime_to_int64(data)
-            if 1 in data.index.nanosecond and "times" not in kwargs:
+            if (1 == data.index.nanosecond).any() and "times" not in kwargs:
                 kwargs["times"] = "int96"
 
         if data.index.name == "":


### PR DESCRIPTION
Previously, line 123 of `collection.py` would raise warnings of deprecation of using `in` operator. 
```
if 1 in data.index.nanosecond and "times" not in kwargs:
```
The exact warning is:
```
pystore/collection.py:123: FutureWarning: Using the ``in`` operator to test for membership in Series is deprecated. To test for membership in the index use ``(s.index == key).any()``. Similarly to test for membership in the values use ``(s == key).any()``
```
A simple change to the following removes the FutureWarning in pandas 1.2.0. 
```
if (1 == data.index.nanosecond).any() and "times" not in kwargs:
```