### PR TITLE
add timezone to imports

### DIFF
--- a/pystore/utils.py
+++ b/pystore/utils.py
@@ -19,7 +19,7 @@
 # limitations under the License.
 
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import shutil
 import pandas as pd


### PR DESCRIPTION
Fixing issue #81 

Need to import timezone from datetime to avoid the following error,
"name 'timezone' is not defined"

modify line 22 to below:
from datetime import datetime, timezone